### PR TITLE
Add automatic creation of release archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: make release archive
+on:
+  release:
+    types: [published]
+jobs:
+  upload-archive:
+    runs-on: ubuntu-latest
+    env:
+      ARCHIVE_NAME: "matrices.zip"
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: make archive
+        run: zip -r $ARCHIVE_NAME *
+      - name: upload to the release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ env.ARCHIVE_NAME }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
Tested on a [pre-release](https://github.com/dyfer/atk-matrices/releases/tag/release-test-03) and a [release](https://github.com/dyfer/atk-matrices/releases/tag/release-test-04) on my fork, I think it should work!